### PR TITLE
Small code refactor and enabled calico on cluster

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -9,6 +9,8 @@ data "terraform_remote_state" "deploy" {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
 data "aws_vpc" "this" {
   id = data.terraform_remote_state.deploy.outputs.vpc_id
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,6 +5,10 @@ provider "aws" {
 locals {
   cluster_name = "itse-apps-admin-1"
 
+  cluster_features = {
+    "aws_calico" = true
+  }
+
   node_groups = {
     default-nodegroup = {
       desired_capacity = "3"
@@ -24,22 +28,15 @@ locals {
       }
     }
   }
-
-  roles = [
-    {
-      username = "maws-admin"
-      rolearn  = "arn:aws:iam::783633885093:role/maws-admin"
-      groups   = ["system:masters"]
-    },
-  ]
 }
 
 module "eks" {
-  source          = "github.com/mozilla-it/terraform-modules//aws/eks?ref=master"
-  cluster_name    = local.cluster_name
-  cluster_version = "1.17"
-  vpc_id          = data.terraform_remote_state.deploy.outputs.vpc_id
-  cluster_subnets = data.terraform_remote_state.deploy.outputs.public_subnets
-  map_roles       = local.roles
-  node_groups     = local.node_groups
+  source           = "github.com/mozilla-it/terraform-modules//aws/eks?ref=master"
+  cluster_name     = local.cluster_name
+  cluster_version  = "1.17"
+  vpc_id           = data.terraform_remote_state.deploy.outputs.vpc_id
+  cluster_subnets  = data.terraform_remote_state.deploy.outputs.public_subnets
+  cluster_features = local.cluster_features
+  node_groups      = local.node_groups
+  admin_users_arn  = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/maws-admin"]
 }


### PR DESCRIPTION
Small code refactor to take into account alberto's new way of adding admin arns to the cluster.

Sneaked in enabling the `aws_calico` helm chart as well which gives us the ability to add network policies